### PR TITLE
Added a couple tests

### DIFF
--- a/ok_json_test.rb
+++ b/ok_json_test.rb
@@ -18,4 +18,20 @@ class OkJsonTest < MiniTest::Unit::TestCase
     json = '{"message":"á"}'
     assert_equal("á", OkJson.decode(json)['message'])
   end
+
+  def test_decode_bad
+    json = "{\"message\":\"\\ufffd\"}"
+    assert_equal([0xef, 0xbf, 0xbd].pack('C*'), OkJson.decode(json)['message'])
+
+    # The output of the following line on JRuby is:
+    #
+    #  "\u00EF\u00BF\u00BD"
+    #
+    # On MRI, it is
+    #
+    #  "\xEF\xBF\xBD"
+    #
+    # It seems the bytes are exactly the same, only the inspect is different.
+    p OkJson.decode(json)['message']
+  end
 end

--- a/ok_json_test.rb
+++ b/ok_json_test.rb
@@ -7,8 +7,15 @@ require 'minitest/autorun'
 require 'okjson'
 
 class OkJsonTest < MiniTest::Unit::TestCase
-  def test_json_decoder
-    json = OkJson.encode({'message' => "á"})
+  # This is a bug in OKJSON
+  def test_json_encode
+    data = {'message' => "á"}
+    json = OkJson.encode data
+    assert_equal '{"message":"á"}', json
+  end
+
+  def test_json_decode
+    json = '{"message":"á"}'
     assert_equal("á", OkJson.decode(json)['message'])
   end
 end


### PR DESCRIPTION
It looks like one problem is inside OKJSON.  It doesn't seem to handle the unicode characters correctly.

When parsing the wrongly produced JSON, it looks like JRuby and MRI will return the same sequence of bytes.  The difference is that when you inspect the bytes, JRuby looks different than MRI.
